### PR TITLE
Fix(db): don't lost the unique MySQL conn after 8hrs

### DIFF
--- a/src/main/java/cz/bloodbear/oauth2client/velocity/utils/DatabaseManager.java
+++ b/src/main/java/cz/bloodbear/oauth2client/velocity/utils/DatabaseManager.java
@@ -20,7 +20,7 @@ public class DatabaseManager implements DB {
         } catch (ClassNotFoundException e) {
             OAuth2Client.getInstance().getLogger().error(e.getMessage());
         }
-        String url = "jdbc:mysql://" + host + ":" + port + "/" + database + "?useSSL=" + useSSL + "&allowPublicKeyRetrieval=true&serverTimezone=UTC";
+        String url = "jdbc:mysql://" + host + ":" + port + "/" + database + "?useSSL=" + useSSL + "&allowPublicKeyRetrieval=true&serverTimezone=UTC&autoReconnect=true";
         try {
             connection = DriverManager.getConnection(url, username, password);
             createTable();


### PR DESCRIPTION
Seems that after 8 hours, the MySQL connection is lost and we can't retrieve it.
With 2 tables, never joins, that makes SQL requests fast enough so that we don't need to reopen a connection for each CRUD and close it afterward. And obviously pooling and whatnot is overkill.